### PR TITLE
This roundning make scale amount inaccurate

### DIFF
--- a/src/Kdyby/Money/Currency.php
+++ b/src/Kdyby/Money/Currency.php
@@ -198,7 +198,7 @@ class Currency extends Nette\Object implements ICurrency
 	 */
 	public function scaleAmount($amount)
 	{
-		return (int) round($amount * $this->getSubunitsInUnit(), 10);
+		return (int) round($amount * $this->getSubunitsInUnit(), 0);
 	}
 
 

--- a/tests/KdybyTests/Money/Currency.phpt
+++ b/tests/KdybyTests/Money/Currency.phpt
@@ -1,0 +1,16 @@
+<?php
+
+use Kdyby\Money\Currency;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+
+
+test(function() {
+	$currency = new Currency('TST', 100, 'Test Currency');
+	Assert::equal(727, $currency->scaleAmount(7.268));
+	Assert::equal(726, $currency->scaleAmount(7.262));
+	Assert::equal(720, $currency->scaleAmount(7.2));
+	Assert::equal(700, $currency->scaleAmount(7));
+});


### PR DESCRIPTION
This can happened if you try calculate tax rates on your invoice -
34.68 EUR * 20% TAX = 6.936 but retype to int will truncate it to 6.93 not 9.94